### PR TITLE
Fixed the extraction problem on mpq mods and added support to loose mods being merged together

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-d2resurrected",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Vortex game support for Diablo II Resurrected",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { actions, fs, Icon, log, types, selectors, util } from 'vortex-api';
 import { IExtensionContext } from 'vortex-api/lib/types/api';
 
 import { GAME_ID, ID_CASC_VIEW, ID_D2_EXCEL, ID_MPQ_EDITOR, ID_D2_LAUNCHER, VORTEX_MERGED_MOD } from './constants';
-import { testDefaultMod, installDefaultMod } from './installers';
+import { testDefaultMod, installDefaultMod, testLooseMod, installLooseMod } from './installers';
 
 import { ensureMergedEntry, removeMergedEntry } from './mergedMod';
 
@@ -182,6 +182,10 @@ function main(context: IExtensionContext) {
   context.registerInstaller('d2-mod-installer', 25, testDefaultMod,
     (files: string[], destinationPath: string, gameId: string) =>
       installDefaultMod(context.api, files, destinationPath, gameId));
+  
+  context.registerInstaller('d2-loose-installer', 25, testLooseMod,
+  (files: string[], destinationPath: string, gameId: string) =>
+    installLooseMod(context.api, files, destinationPath, gameId));
 
   context.registerMerge((game: types.IGame, discovery: types.IDiscoveryResult) => testMerge(context.api, game, discovery),
     (filePath: string, mergePath: string) => merge(context.api, filePath, mergePath), 'd2-merge-mod');

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -49,7 +49,13 @@ export async function installDefaultMod(api: types.IExtensionApi, files: string[
       const out = path.join(destinationPath, 'out');
       await fs.ensureDirWritableAsync(out);
       for (const mpqFile of mpqs) {
-        await extractMPQ(api, path.join(destinationPath, mpqFile), out);
+        const mpqFilePath = path.join(destinationPath, mpqFile);
+        const stats : fs.Stats = await fs.statAsync(mpqFilePath);
+        if (stats.isFile()) {
+          await extractMPQ(api, mpqFilePath, out);
+        } else if (stats.isDirectory()) {
+          await fs.copyAsync(mpqFilePath, out);
+        }
       }
 
       const instructions: types.IInstruction[] = [{ type: 'setmodtype', value: 'd2-merge-mod' }];

--- a/src/installers.ts
+++ b/src/installers.ts
@@ -79,3 +79,25 @@ export async function installDefaultMod(api: types.IExtensionApi, files: string[
     }
   })
 }
+
+export function testLooseMod(files: string[], gameId: string): Promise<types.ISupportedResult> {
+  return Promise.resolve({ supported: gameId === GAME_ID && !files.find(file => path.extname(file) === MPQ_EXT)
+    && !!files.find(file => path.basename(file) === 'data'), requiredFiles: [] });
+}
+
+export async function installLooseMod(api: types.IExtensionApi, files: string[], destinationPath: string, gameId: string): Promise<types.IInstallResult> {
+ const instructions: types.IInstruction[] = files.reduce((accum, file) => {
+   if (accum.length === 0) {
+     accum.push({ type: 'setmodtype', value: 'd2-merge-mod' });
+    }
+    if (path.basename(file) === 'data') {
+       accum.push({
+        type: 'copy',
+        source: file,
+        destination: path.basename(file)
+      })
+    }
+    return accum;
+  }, []);
+  return Promise.resolve({ instructions });
+}


### PR DESCRIPTION
Fixed the extraction problem for the mpq mods, when they were using the new folder structure and no mpq archives anymore.

Also added support for loose mod extraction by installing their data folder as root and marked them to be merged just liked extracted mpq mods would.

The nexus mod page is quite a mess, since nobody uses Vortex so far, so I hope more people can use it now.

I don't know if we should add another information text, that the loose file merging does of course conflict a lot and won't result into a perfect merge. Right now the installation shows no hint, since I didn't know where to add it properly.

There is also a release of v0.1.3 provided at my github fork -> [here](https://github.com/Kongolan/game-d2resurrection/releases/tag/v0.1.3)

Maybe you can review this. Thank you!